### PR TITLE
Adds CoffeeCompile and other commands in addition to syntax highlighting

### DIFF
--- a/ftdetect/litcoffee.vim
+++ b/ftdetect/litcoffee.vim
@@ -1,1 +1,2 @@
 autocmd BufNewFile,BufRead *.litcoffee   set syntax=coffee
+autocmd BufNewFile,BufRead *.litcoffee   runtime ftplugin/coffee.vim


### PR DESCRIPTION
Apparently the vim-coffee-script plugins only care about the .coffee files by default and I forgot to RTFM.